### PR TITLE
fix: additional requirements on build host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 ARG TARGETPLATFORM
 
-RUN apt-get update && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.6 ca-certificates=20240203 && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.6 ca-certificates=20240203 gcc g++ jq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/bin && touch /usr/bin/bazel  # allows the following `curl` to write, unsure why
 
@@ -10,5 +10,9 @@ RUN case "$TARGETPLATFORM" in \
   "linux/arm64") curl -Lo /usr/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.8.1/bazelisk-linux-arm64 || exit 1;; \
   *) echo "unknown platform: [$TARGETPLATFORM]"; exit 1;; \
   esac && chmod +x /usr/bin/bazel
+
+RUN useradd -ms /bin/bash builder
+USER builder
+WORKDIR /home/builder
 
 ENTRYPOINT [ "/usr/bin/bazel" ]


### PR DESCRIPTION
Seems we need g++ and gcc for Bazel's native CC toolchain discovery, plus I'm using `jq` in the workspace config